### PR TITLE
fix: show latest notices first in the notice carousel

### DIFF
--- a/src/layouts/IndexPage.jsx
+++ b/src/layouts/IndexPage.jsx
@@ -28,7 +28,11 @@ export const IndexPage = () => {
         )
           .then((res) => res.json())
           .then((data) => {
-            setNewsList(data.windows);
+            // Entries are ordered from oldest to latest in the json file, but we want
+            // to show the latest one first in the carousel.
+            //
+            // Also, show only at most 7 of the most recent ones.
+            setNewsList(data.windows.reverse().slice(0, 7));
           });
       } catch (error) {
         console.log(error);


### PR DESCRIPTION
Show the latest notice first in the notice carousel in the home page,
and show at most 7 of them.