### PR TITLE
fix: [CI] cryptography bump to 35.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,6 @@ jobs:
       - name: spid-sp-test
         run: |
           sudo apt update && sudo apt install xmlsec1
-          pip install spid-sp-test>=0.9.2
+          pip install --upgrade pip
+          pip install "spid-sp-test>=0.9.2" "cryptography==35.0.0"
           spid_sp_test --metadata-url file://$GITHUB_WORKSPACE/static/saml2/metadata.xml --extra --debug ERROR


### PR DESCRIPTION
this PR aims to solve the following error raised during CI:

````
ERROR: spid-compliant-certificates 0.5.3 has requirement cryptography==35.0.0, but you'll have cryptography 38.0.1 which is incompatible.
````
